### PR TITLE
Change repository type to "hiring-challenge" in OpsLevel file

### DIFF
--- a/opslevel.yml
+++ b/opslevel.yml
@@ -1,22 +1,15 @@
----
 version: 1
 service:
     name: Mobile Challenge
-    lifecycle:
-    tier:
-    product:
+    description: Pleo's mobile challenge
     owner: mobile_core
     language: TypeScript
-    framework:
-    description: Pleo's mobile challenge
     aliases:
         - mobile-challenge
     tags:
         - key: type
-          value: application
+          value: hiring-challenge
     repositories:
         - name: pleo-io/mobile-challenge
           path: "/"
           provider: github
-    tools:
-    dependencies:


### PR DESCRIPTION
This is to be in line with most of the other repositories that we use as "hiring challenges":
https://app.opslevel.com/services?filter[0][key]=tags.type&filter[0][type]=equals&filter[0][arg]=hiring-challenge