### PR TITLE
[SEC-4706] Clean up obsolete properties from port-component.yaml

### DIFF
--- a/port-component.yaml
+++ b/port-component.yaml
@@ -9,22 +9,6 @@ steward: team-mobile-core
 # (optional) The description for this component will be picked up from the related GitHub repository. If you need to provide a different one, you can use this field
 # description: This is a description about your component
 
-# Any tags relevant to your components and/or mandated by platform teams
-tags:
-
-  # Describes type of component the repository defines.
-  #
-  # Use:
-  #  - `type: service` for web services (moons)
-  #  - `type: application` for downloadable software (such as an iOS/Android app,
-  #     CLI tool, standalone executable). This also includes e.g. web apps.
-  #  - `type: library` for software used by other components
-  #  - `type: configuration` for repos that contain pure configuration (such as
-  #    setup of DangerJS or Renovate).
-  #  - `type: documentation` for repos that mostly contain documentation.
-  #  - `type: hiring-challenge` for our hiring challenges.
-  type: hiring-challenge
-
 # (optional) Relevant repositories which are relevant to this component excluding the repository hosting this file. The current repository will be linked by default in Port.
 # Example: Terraform folder which hosts the architecture definition for a backend service (moon)
 # related_repositories:


### PR DESCRIPTION
# Remove `tags` block from `port-component.yaml`

The data previously captured in the `tags` block (`type`, `DataClassification`, `PersonalData`, `SensitivePersonalData`, `CustomerData`, `PCIData`, `CustomerAccountData`, `AMLData`) is now managed via GitHub custom properties, making this block redundant.

This PR removes the entire `tags` block from your `port-component.yaml`.

## What do you need to do?

1. Review and approve :D
2. If not already done, enter custom properties for this repository (walkthrough [here](https://app.notion.com/p/pleo/Custom-properties-in-GitHub-23053cae7a6680bb8f16d860bf15460a?source=copy_link))
3. Let us know if you have any questions or concerns in this PR or in #ask-security.
